### PR TITLE
Allow string track names

### DIFF
--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -512,7 +512,7 @@
           "markdownDescription": "Path to the JSON file with service account key used to authenticate with Google Play. [Learn more](https://expo.fyi/creating-google-service-account)"
         },
         "track": {
-          "enum": ["beta", "alpha", "internal", "production"],
+          "type": "string",
           "description": "The track of the application to use. Learn more: https://support.google.com/googleplay/android-developer/answer/9859348?hl=en",
           "markdownDescription": "The [track of the application](https://support.google.com/googleplay/android-developer/answer/9859348?hl=en) to use.",
           "markdownEnumDescriptions": [

--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -513,6 +513,8 @@
         },
         "track": {
           "type": "string",
+          "minLength": 1,
+          "maxLength": 50,
           "description": "The track of the application to use. Learn more: https://support.google.com/googleplay/android-developer/answer/9859348?hl=en",
           "markdownDescription": "The [track of the application](https://support.google.com/googleplay/android-developer/answer/9859348?hl=en) to use.",
           "markdownEnumDescriptions": [

--- a/packages/eas-json/src/submit/schema.ts
+++ b/packages/eas-json/src/submit/schema.ts
@@ -4,9 +4,7 @@ import { AndroidReleaseStatus, AndroidReleaseTrack } from './types';
 
 export const AndroidSubmitProfileSchema = Joi.object({
   serviceAccountKeyPath: Joi.string(),
-  track: Joi.string()
-    .valid(...Object.values(AndroidReleaseTrack))
-    .default(AndroidReleaseTrack.internal),
+  track: Joi.string().min(1).max(50).default(AndroidReleaseTrack.internal),
   releaseStatus: Joi.string()
     .valid(...Object.values(AndroidReleaseStatus))
     .default(AndroidReleaseStatus.completed),


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->
<!-- 
/changelog-entry bug-fix Allow a string of 1-50 characters as a track name
-->

# Why

Previously, the Android submit track in eas.json only allowed a fixed set of values ("beta", "alpha", "internal", "production"). However, Google Play supports custom track names, and users may need to specify arbitrary track names for advanced workflows. This PR enables more flexible usage by allowing any string of 1-50 characters as a track name.
Track name follows the rule defined by Google textfield. See the image below.

1. When textfield is empty
    ![Empty Trackname textfield](https://github.com/user-attachments/assets/cc9d57cb-1969-4c4d-b4e5-5bba41c7af56)
2. When textfield has an input within 50 characters
    ![Track name textfield within 50 characters](https://github.com/user-attachments/assets/f3dcd088-5917-4289-858e-46f7588e35da)
3. When textfied has an input over 50 characters
    ![Track name textfield over 50 characters](https://github.com/user-attachments/assets/7e21d8f1-fba4-426d-9488-35631bf06945)


# How

- Updated the Joi runtime schema in `packages/eas-json/src/submit/schema.ts` to allow any string of 1-50 characters for the Android submit track property.
- Updated the JSON schema in `packages/eas-json/schema/eas.schema.json` to add `minLength` and `maxLength` for the track property, ensuring IDE and documentation support matches runtime validation.
- Added and updated tests in `packages/eas-json/src/__tests__/submitProfiles-test.ts` to cover:
  - Valid custom track names within 50 characters
  - Invalid track names (empty string, over 50 characters)
  - Default value behavior when track is omitted

# Test Plan

- Ran the test suite to ensure all new and existing tests pass.
- Verified that:
  - A custom track name (e.g., `my-custom-track`) is accepted.
  - An empty string or a string longer than 50 characters is rejected.
  - Omitting the track property defaults to `internal`.

If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
![Test results on terminal](https://github.com/user-attachments/assets/707cdfd2-8ac5-4743-b272-b7a34e0382c1)

